### PR TITLE
chore: react-vite 側の重複した prepare スクリプトを削除

### DIFF
--- a/packages/react-vite/package.json
+++ b/packages/react-vite/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "prepare": "git config --local core.hooksPath .githook || echo 'Can not set git hooks' ",
     "format": "biome format ./src --write",
     "lint": "biome lint ./src --files-ignore-unknown=true",
     "lint:fix": "biome check --apply ./src --files-ignore-unknown=true",


### PR DESCRIPTION
## Summary
- pnpm install 時に root と `packages/react-vite` の両方で同じ `git config --local core.hooksPath .githook` が走っていた
- 同じ設定を 2 回適用するだけで効果は変わらないため、`packages/react-vite/package.json` 側を削除し、root の `prepare` のみで Git フックを設定するようにした

## Test plan
- [ ] `pnpm install` のログで `prepare$ ...` が 1 回（root 側のみ）になることを確認
- [ ] `git config --local --get core.hooksPath` が `.githook` を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)